### PR TITLE
[FE-292] add permissions level to tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "ottertune_role" {
 
 data "aws_iam_policy_document" "ottertune_db_policy" {
   statement {
-    actions = var.permissions_level == "write_limited" ? [
+    actions = flatten([
       "budgets:Describe*",
       "ce:Describe*",
       "ce:Get*",
@@ -47,22 +47,11 @@ data "aws_iam_policy_document" "ottertune_db_policy" {
       "pi:GetResourceMetrics",
       "rds:Describe*",
       "rds:List*",
+      var.permissions_level == "write_limited" ? [
       "rds:ModifyDBInstance",
       "rds:ModifyDBCluster",
-    ] : [
-      "budgets:Describe*",
-      "ce:Describe*",
-      "ce:Get*",
-      "ce:List*",
-      "cloudwatch:Describe*",
-      "cloudwatch:Get*",
-      "cloudwatch:List*",
-      "iam:SimulatePrincipalPolicy",
-      "pi:DescribeDimensionKeys",
-      "pi:GetResourceMetrics",
-      "rds:Describe*",
-      "rds:List*",
-    ]
+      ] : []
+    ])
     resources = ["*"]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "iam_role_name" {
   default = "OtterTuneRole"
 }
 
+variable "permissions_level" {
+  description = "The permissions level associated with the created role. Currently the two options are: read_only | write_limited"
+  type    = string
+  default = "read_only"
+}
+
 variable "tunable_parameter_group_arns" {
   description = <<-EOT
                    Pass in the parameter group ARNs that you would like to allow OtterTune to optimize. 


### PR DESCRIPTION
# What

Adds new variable `permissions_level` to the terraform flow

# Background

This is related to the OtterTune controlled Parameter Groups work.

# Test Plan

Terraformed new policy at specified level and successfully created IAM role with expected permissions
